### PR TITLE
allow different MB model, fixed temp. lapse rate issue

### DIFF
--- a/oggm/core/climate.py
+++ b/oggm/core/climate.py
@@ -129,20 +129,9 @@ def process_custom_climate_data(gdir, y0=None, y1=None, output_filesuffix=None):
     iprcp = prcp[:, ilat, ilon]
     nc_ts.close()
 
-    # Should we compute the gradient?
-    use_grad = cfg.PARAMS['temp_use_local_gradient']
-    igrad = None
-    if use_grad:
-        igrad = np.zeros(len(time)) * np.NaN
-        for t, loct in enumerate(ttemp):
-            slope, _, _, p_val, _ = stats.linregress(thgt,
-                                                     loct.flatten())
-            igrad[t] = slope if (p_val < 0.01) else np.NaN
-
     gdir.write_monthly_climate_file(time, iprcp, itemp, ihgt,
                                     ref_pix_lon, ref_pix_lat,
                                     filesuffix=output_filesuffix,
-                                    gradient=igrad,
                                     source=fpath)
 
 

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -3562,6 +3562,7 @@ def run_from_climate_data(gdir, ys=None, ye=None, min_ys=None, max_ys=None,
                           store_fl_diagnostics=None,
                           climate_filename='climate_historical',
                           mb_model=None,
+                          mb_model_class=MonthlyTIModel,
                           climate_input_filesuffix='', output_filesuffix='',
                           init_model_filesuffix=None, init_model_yr=None,
                           init_model_fls=None, zero_initial_glacier=False,
@@ -3604,8 +3605,11 @@ def run_from_climate_data(gdir, ys=None, ye=None, min_ys=None, max_ys=None,
         'gcm_data'
     mb_model : :py:class:`core.MassBalanceModel`
         User-povided MassBalanceModel instance. Default is to use a
-        MonthlyTIModel together with the provided parameters climate_filename,
+        mb_model_class instance (default MonthlyTIModel)
+        together with the provided parameters climate_filename,
         bias and climate_input_filesuffix.
+    mb_model_class : MassBalanceModel class
+        the MassBalanceModel class to use, default is MonthlyTIModel
     climate_input_filesuffix: str
         filesuffix for the input climate file
     output_filesuffix : str
@@ -3678,7 +3682,7 @@ def run_from_climate_data(gdir, ys=None, ye=None, min_ys=None, max_ys=None,
 
     if mb_model is None:
         mb_model = MultipleFlowlineMassBalance(gdir,
-                                               mb_model_class=MonthlyTIModel,
+                                               mb_model_class=mb_model_class,
                                                filename=climate_filename,
                                                bias=bias,
                                                input_filesuffix=climate_input_filesuffix)

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -356,7 +356,6 @@ class LinearMassBalance(MassBalanceModel):
 
 class MonthlyTIModel(MassBalanceModel):
     """Monthly temperature index model.
-
     """
     def __init__(self, gdir,
                  filename='climate_historical',
@@ -386,7 +385,8 @@ class MonthlyTIModel(MassBalanceModel):
             if this flowline has been calibrated alone and has specific
             model parameters.
         melt_f : float, optional
-            set to the value of the melt factor you want to use
+            set to the value of the melt factor you want to use,
+            here the unit is kg m-2 day-1 K-1
             (the default is to use the calibrated value).
         temp_bias : float, optional
             set to the value of the temperature bias you want to use
@@ -507,7 +507,7 @@ class MonthlyTIModel(MassBalanceModel):
             # Read timeseries and correct it
             self.temp = nc.variables['temp'][pok].astype(np.float64) + self._temp_bias
             self.prcp = nc.variables['prcp'][pok].astype(np.float64) * self._prcp_fac
-            if 'gradient' in nc.variables:
+            if 'gradient' in nc.variables and cfg.PARAMS['temp_use_local_gradient']:
                 grad = nc.variables['gradient'][pok].astype(np.float64)
                 # Security for stuff that can happen with local gradients
                 g_minmax = cfg.PARAMS['temp_local_gradient_bounds']
@@ -725,7 +725,7 @@ class ConstantMassBalance(MassBalanceModel):
         the years of the period
     """
 
-    def __init__(self, gdir, massbalance_model_class=MonthlyTIModel,
+    def __init__(self, gdir, mb_model_class=MonthlyTIModel,
                  y0=None, halfsize=15,
                  **kwargs):
         """Initialize
@@ -734,19 +734,19 @@ class ConstantMassBalance(MassBalanceModel):
         ----------
         gdir : GlacierDirectory
             the glacier directory
-        massbalance_model_class : MassBalanceModel class
+        mb_model_class : MassBalanceModel class
             the MassBalanceModel to use for the constant climate
         y0 : int, required
             the year at the center of the period of interest.
         halfsize : int, optional
             the half-size of the time window (window size = 2 * halfsize + 1)
         **kwargs:
-            keyword arguments to pass to the massbalance_model_class
+            keyword arguments to pass to the mb_model_class
         """
 
         super().__init__()
-        self.mbmod = massbalance_model_class(gdir,
-                                             **kwargs)
+        self.mbmod = mb_model_class(gdir,
+                                    **kwargs)
 
         if y0 is None:
             raise InvalidParamsError('Please set `y0` explicitly')
@@ -920,7 +920,7 @@ class RandomMassBalance(MassBalanceModel):
     approaches based on gaussian assumptions.
     """
 
-    def __init__(self, gdir, massbalance_model_class=MonthlyTIModel,
+    def __init__(self, gdir, mb_model_class=MonthlyTIModel,
                  y0=None, halfsize=15, seed=None,
                  all_years=False, unique_samples=False, prescribe_years=None,
                  **kwargs):
@@ -930,7 +930,7 @@ class RandomMassBalance(MassBalanceModel):
         ----------
         gdir : GlacierDirectory
             the glacier directory
-        massbalance_model_class : MassBalanceModel class
+        mb_model_class : MassBalanceModel class
             the MassBalanceModel to use for the random shuffle
         y0 : int, required
             the year at the center of the period of interest.
@@ -952,12 +952,12 @@ class RandomMassBalance(MassBalanceModel):
             original timeseries. Overrides `y0`, `halfsize`, `all_years`,
             `unique_samples` and `seed`.
         **kwargs:
-            keyword arguments to pass to the massbalance_model_class
+            keyword arguments to pass to the mb_model_class
         """
 
         super().__init__()
         self.valid_bounds = [-1e4, 2e4]  # in m
-        self.mbmod = massbalance_model_class(gdir, **kwargs)
+        self.mbmod = mb_model_class(gdir, **kwargs)
 
         # Climate period
         self.prescribe_years = prescribe_years
@@ -1204,9 +1204,9 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
             the glacier directory
         fls : list, optional
             list of flowline objects to use (defaults to 'model_flowlines')
-        mb_model_class : class, optional
-            the mass balance model to use (e.g. MonthlyTIModel,
-            ConstantMassBalance...)
+        mb_model_class : MassBalanceModel class
+            the MassBalanceModel to use (default is MonthlyTIModel,
+            alternatives are e.g. ConstantMassBalance...)
         use_inversion_flowlines: bool, optional
             use 'inversion_flowlines' instead of 'model_flowlines'
         kwargs : kwargs to pass to mb_model_class
@@ -1459,6 +1459,7 @@ def mb_calibration_from_geodetic_mb(gdir,
                                     temp_bias=0,
                                     temp_bias_min=None,
                                     temp_bias_max=None,
+                                    mb_model_class=MonthlyTIModel,
                                     ):
     """Determine the mass balance parameters from a scalar mass-balance value.
 
@@ -1486,6 +1487,9 @@ def mb_calibration_from_geodetic_mb(gdir,
         given, all years between this range (excluding the last one) are used.
         If a list  of years is given, all these will be used (useful for
         data with gaps)
+    mb_model_class : MassBalanceModel class
+            the MassBalanceModel to use for the calibration
+            default is MonthlyTIModel
     """
 
     # Param constraints
@@ -1566,7 +1570,7 @@ def mb_calibration_from_geodetic_mb(gdir,
         prcp_fac = prcp_scaling_factor    
 
     # Create the MB model we will calibrate
-    mb_mod = MonthlyTIModel(gdir,
+    mb_mod = mb_model_class(gdir,
                             melt_f=melt_f,
                             temp_bias=temp_bias,
                             prcp_fac=prcp_fac,
@@ -1775,7 +1779,9 @@ def apparent_mb_from_linear_mb(gdir, mb_gradient=3., ela_h=None):
 
 
 @entity_task(log, writes=['inversion_flowlines'])
-def apparent_mb_from_any_mb(gdir, mb_model=None, mb_years=None):
+def apparent_mb_from_any_mb(gdir, mb_model=None,
+                            mb_model_class=MonthlyTIModel,
+                            mb_years=None):
     """Compute apparent mb from an arbitrary mass balance profile.
 
     This searches for a mass balance residual to add to the mass balance
@@ -1786,8 +1792,10 @@ def apparent_mb_from_any_mb(gdir, mb_model=None, mb_years=None):
     gdir : :py:class:`oggm.GlacierDirectory`
         the glacier directory to process
     mb_model : :py:class:`oggm.core.massbalance.MassBalanceModel`
-        the mass balance model to use - if None, will use the default OGGM
-        one.
+        the mass balance model to use - if None, will use the
+        one given by mb_model_class
+    mb_model_class : MassBalanceModel class
+        the MassBalanceModel class to use, default is MonthlyTIModel
     mb_years : array, or tuple of length 2 (range)
         the array of years from which you want to average the MB for (for
         mb_model only). If an array of length 2 is given, all years
@@ -1806,7 +1814,7 @@ def apparent_mb_from_any_mb(gdir, mb_model=None, mb_years=None):
     fls = gdir.read_pickle('inversion_flowlines')
 
     if mb_model is None:
-        mb_model = MonthlyTIModel(gdir)
+        mb_model = mb_model_class(gdir)
 
     if mb_years is None:
         mb_years = cfg.PARAMS['geodetic_mb_period']
@@ -1859,7 +1867,8 @@ def fixed_geometry_mass_balance(gdir, ys=None, ye=None, years=None,
                                 climate_filename='climate_historical',
                                 climate_input_filesuffix='',
                                 temperature_bias=None,
-                                precipitation_factor=None):
+                                precipitation_factor=None,
+                                mb_model_class=MonthlyTIModel):
     """Computes the mass balance with climate input from e.g. CRU or a GCM.
 
     Parameters
@@ -1889,12 +1898,14 @@ def fixed_geometry_mass_balance(gdir, ys=None, ye=None, years=None,
         multiply a factor to the precipitation time series
         default is None and means that the precipitation factor from the
         calibration is applied which is cfg.PARAMS['prcp_scaling_factor']
+    mb_model_class : MassBalanceModel class
+        the MassBalanceModel class to use, default is MonthlyTIModel
     """
 
     if monthly_step:
         raise NotImplementedError('monthly_step not implemented yet')
 
-    mbmod = MultipleFlowlineMassBalance(gdir, mb_model_class=MonthlyTIModel,
+    mbmod = MultipleFlowlineMassBalance(gdir, mb_model_class=mb_model_class,
                                         filename=climate_filename,
                                         use_inversion_flowlines=use_inversion_flowlines,
                                         input_filesuffix=climate_input_filesuffix)
@@ -1918,7 +1929,8 @@ def fixed_geometry_mass_balance(gdir, ys=None, ye=None, years=None,
 
 @entity_task(log)
 def compute_ela(gdir, ys=None, ye=None, years=None, climate_filename='climate_historical',
-                temperature_bias=None, precipitation_factor=None, climate_input_filesuffix=''):
+                temperature_bias=None, precipitation_factor=None, climate_input_filesuffix='',
+                mb_model_class=MonthlyTIModel):
 
     """Computes the ELA of a glacier for a for given years and climate.
 
@@ -1943,9 +1955,11 @@ def compute_ela(gdir, ys=None, ye=None, years=None, climate_filename='climate_hi
         multiply a factor to the precipitation time series
         default is None and means that the precipitation factor from the
         calibration is applied which is cfg.PARAMS['prcp_scaling_factor']
+    mb_model_class : MassBalanceModel class
+        the MassBalanceModel class to use, default is MonthlyTIModel
     """
 
-    mbmod = MonthlyTIModel(gdir, filename=climate_filename,
+    mbmod = mb_model_class(gdir, filename=climate_filename,
                            input_filesuffix=climate_input_filesuffix)
 
     if temperature_bias is not None:

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -507,14 +507,8 @@ class MonthlyTIModel(MassBalanceModel):
             # Read timeseries and correct it
             self.temp = nc.variables['temp'][pok].astype(np.float64) + self._temp_bias
             self.prcp = nc.variables['prcp'][pok].astype(np.float64) * self._prcp_fac
-            if 'gradient' in nc.variables and cfg.PARAMS['temp_use_local_gradient']:
-                grad = nc.variables['gradient'][pok].astype(np.float64)
-                # Security for stuff that can happen with local gradients
-                g_minmax = cfg.PARAMS['temp_local_gradient_bounds']
-                grad = np.where(~np.isfinite(grad), default_grad, grad)
-                grad = clip_array(grad, g_minmax[0], g_minmax[1])
-            else:
-                grad = self.prcp * 0 + default_grad
+
+            grad = self.prcp * 0 + default_grad
             self.grad = grad
             self.ref_hgt = nc.ref_hgt
             self.climate_source = nc.climate_source

--- a/oggm/shop/cru.py
+++ b/oggm/shop/cru.py
@@ -175,18 +175,6 @@ def process_cru_data(gdir, tmp_file=None, pre_file=None, y0=None, y1=None,
     hgt_f = loc_hgt[isok].flatten()
     assert len(hgt_f) > 0.
 
-    # Should we compute the gradient?
-    use_grad = cfg.PARAMS['temp_use_local_gradient']
-    ts_grad = None
-    if use_grad and len(hgt_f) >= 5:
-        ts_grad = np.zeros(12) * np.NaN
-        for i in range(12):
-            loc_tmp_mth = loc_tmp[i, ...][isok].flatten()
-            slope, _, _, p_val, _ = stats.linregress(hgt_f, loc_tmp_mth)
-            ts_grad[i] = slope if (p_val < 0.01) else np.NaN
-        # convert to a timeseries
-        ts_grad = np.asarray(ts_grad.tolist() * ny)
-
     # maybe this will throw out of bounds warnings
     nc_ts_tmp.set_subset(corners=((lon, lat), (lon, lat)), margin=1)
     nc_ts_pre.set_subset(corners=((lon, lat), (lon, lat)), margin=1)
@@ -276,7 +264,6 @@ def process_cru_data(gdir, tmp_file=None, pre_file=None, y0=None, y1=None,
     gdir.write_monthly_climate_file(time, ts_pre.values, ts_tmp.values,
                                     loc_hgt, loc_lon, loc_lat,
                                     filesuffix=output_filesuffix,
-                                    gradient=ts_grad,
                                     source=nc_ts_tmp._nc.title[:10])
 
     ncclim._nc.close()
@@ -376,17 +363,6 @@ def process_dummy_cru_file(gdir, sigma_temp=2, sigma_prcp=0.5, seed=None,
     hgt_f = loc_hgt[isok].flatten()
     assert len(hgt_f) > 0.
 
-    # Should we compute the gradient?
-    use_grad = cfg.PARAMS['temp_use_local_gradient']
-    ts_grad = None
-    if use_grad and len(hgt_f) >= 5:
-        ts_grad = np.zeros(12) * np.NaN
-        for i in range(12):
-            loc_tmp_mth = loc_tmp[i, ...][isok].flatten()
-            slope, _, _, p_val, _ = stats.linregress(hgt_f, loc_tmp_mth)
-            ts_grad[i] = slope if (p_val < 0.01) else np.NaN
-        # convert to a timeseries
-        ts_grad = np.asarray(ts_grad.tolist() * ny)
 
     # Make DataArrays
     rng = np.random.RandomState(seed)
@@ -414,7 +390,6 @@ def process_dummy_cru_file(gdir, sigma_temp=2, sigma_prcp=0.5, seed=None,
 
     gdir.write_monthly_climate_file(time, ts_pre.values, ts_tmp.values,
                                     loc_hgt, loc_lon, loc_lat,
-                                    gradient=ts_grad,
                                     filesuffix=output_filesuffix,
                                     source='CRU CL2 and some randomness')
     ncclim._nc.close()

--- a/oggm/shop/ecmwf.py
+++ b/oggm/shop/ecmwf.py
@@ -183,19 +183,13 @@ def process_ecmwf_data(gdir, dataset=None, ensemble_member=0,
             ds = ds.isel(points=np.argmin(c.data))
         hgt = ds['z'].data / cfg.G
 
-    gradient = None
     temp_std = None
 
-    # Should we compute the gradient?
-    if cfg.PARAMS['temp_use_local_gradient']:
-        raise NotImplementedError('`temp_use_local_gradient` not '
-                                  'implemented yet')
     if dataset == 'ERA5dr':
         with xr.open_dataset(get_ecmwf_file(dataset, 'lapserates')) as ds:
             _check_ds_validity(ds)
             ds = ds.sel(time=slice(f'{y0}-01-01', f'{y1}-12-01'))
             ds = ds.sel(longitude=lon, latitude=lat, method='nearest')
-            gradient = ds['lapserate'].data
 
         with xr.open_dataset(get_ecmwf_file(dataset, 'tempstd')) as ds:
             _check_ds_validity(ds)
@@ -206,6 +200,5 @@ def process_ecmwf_data(gdir, dataset=None, ensemble_member=0,
     # OK, ready to write
     gdir.write_monthly_climate_file(time, prcp, temp, hgt, ref_lon, ref_lat,
                                     filesuffix=output_filesuffix,
-                                    gradient=gradient,
                                     temp_std=temp_std,
                                     source=dataset)

--- a/oggm/shop/histalp.py
+++ b/oggm/shop/histalp.py
@@ -154,18 +154,7 @@ def process_histalp_data(gdir, y0=None, y1=None, output_filesuffix=None):
     nc_ts_tmp._nc.close()
     nc_ts_pre._nc.close()
 
-    # Should we compute the gradient?
-    use_grad = cfg.PARAMS['temp_use_local_gradient']
-    igrad = None
-    if use_grad:
-        igrad = np.zeros(len(time)) * np.NaN
-        for t, loct in enumerate(temp):
-            slope, _, _, p_val, _ = stats.linregress(hgt.flatten(),
-                                                     loct.flatten())
-            igrad[t] = slope if (p_val < 0.01) else np.NaN
-
     gdir.write_monthly_climate_file(time, prcp[:, 1, 1], temp[:, 1, 1],
                                     hgt[1, 1], ref_lon[1], ref_lat[1],
-                                    gradient=igrad,
                                     filesuffix=output_filesuffix,
                                     source=source)

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -1199,29 +1199,6 @@ class TestClimate(unittest.TestCase):
             np.testing.assert_allclose(ref_t, nc_r.variables['temp'][:])
             np.testing.assert_allclose(ref_p, nc_r.variables['prcp'][:])
 
-    @pytest.mark.slow
-    def test_distribute_climate_grad(self):
-
-        hef_file = get_demo_file('Hintereisferner_RGI5.shp')
-        cfg.PARAMS['temp_use_local_gradient'] = True
-        entity = gpd.read_file(hef_file).iloc[0]
-
-        gdir = oggm.GlacierDirectory(entity, base_dir=self.testdir)
-        gis.define_glacier_region(gdir)
-        climate.process_custom_climate_data(gdir)
-
-        ci = gdir.get_climate_info()
-        self.assertEqual(ci['baseline_yr_0'], 1802)
-        self.assertEqual(ci['baseline_yr_1'], 2002)
-
-        with xr.open_dataset(gdir.get_filepath('climate_historical')) as ds:
-            grad = ds['gradient'].data
-            try:
-                assert np.std(grad) > 0.0001
-            except TypeError:
-                pass
-        cfg.PARAMS['temp_use_local_gradient'] = False
-
     def test_distribute_climate_parallel(self):
 
         hef_file = get_demo_file('Hintereisferner_RGI5.shp')

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -134,7 +134,6 @@ def up_to_inversion(reset=False):
 
     if reset:
         # Use histalp for the actual inversion test
-        cfg.PARAMS['temp_use_local_gradient'] = True
         cfg.PARAMS['baseline_climate'] = 'HISTALP'
         workflow.climate_tasks(gdirs, overwrite_gdir=True,
                                override_missing=-500)
@@ -166,7 +165,6 @@ def up_to_distrib(reset=False):
     if reset:
         # Use CRU
         cfg.PARAMS['prcp_scaling_factor'] = 2.5
-        cfg.PARAMS['temp_use_local_gradient'] = False
         cfg.PARAMS['baseline_climate'] = 'CRU'
         with warnings.catch_warnings():
             # There is a warning from salem


### PR DESCRIPTION
- everywhere in the code where `MonthlyTIModel` occurs, I replaced it with `mb_model_class` and added a keyword argument to the respective class/function with `mb_model_class=MonthlyTIModel`
- I did not do it inside of `dynamic_spinup.py`, because I was unsure if I do everything right. But I believe that it is ok, because the dynamic_spinup does not need to be the first thing that is compatible with different MB models? And that can be changed later.  
- in `MonthlyTIModel`, the potentially existing temperature lapse rate gradient from the processed climate data is now only applied if `cfg.PARAMS['temp_use_local_gradient']=True` . I think, no one actively wants to use it at the moment? Otherwise it can happen that the variable temperature lapse rates are used by mistake over the calibration period, while the default temperature lapse rate gradient is applied for the projections. 

I haven't included a real variant of a `MonthlyTIModel`, because I am stuck, and don't know from which direction I should go to solve it.  But I still believe that it is nice to already have the possibility to change the MB model. 
