### PR TITLE
renaming and typos

### DIFF
--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -645,7 +645,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
             from oggm.core.flowline import FluxBasedModel
             evolution_model = FluxBasedModel
 
-        # conduct historical run before dynamic mu calibration
+        # conduct historical run before dynamic melt_f calibration
         # (for comparison to old default behavior)
         workflow.execute_entity_task(tasks.run_from_climate_data, gdirs,
                                      min_ys=y0, ye=ye,

--- a/oggm/core/dynamic_spinup.py
+++ b/oggm/core/dynamic_spinup.py
@@ -1939,7 +1939,7 @@ def run_dynamic_melt_f_calibration(
 
     # Here start with own spline minimisation algorithm
     def minimise_with_spline_fit(fct_to_minimise, melt_f_guess, mismatch):
-        # defines limits of mu in accordance to maximal allowed change
+        # defines limits of melt_f in accordance to maximal allowed change
         # between iterations
         melt_f_limits = [melt_f_initial - melt_f_max_step_length,
                          melt_f_initial + melt_f_max_step_length]

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -489,7 +489,7 @@ class MonthlyTIModel(MassBalanceModel):
                 raise InvalidWorkflowError('We now work exclusively with '
                                            'calendar years.')
 
-            # Quick trick because we now the size of our array
+            # Quick trick because we know the size of our array
             years = np.repeat(np.arange(time[-1].year - ny + 1,
                                         time[-1].year + 1), 12)
             pok = slice(None)  # take all is default (optim)
@@ -1371,7 +1371,7 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
 
 
 def _fallback_mb_calibration(gdir):
-    """A Fallback function if climate.mu_star_calibration raises an Error.
+    """A Fallback function if massbalance.mb_calibration_from_scalar_mb raises an Error.
 
     If calibration fails, this function will still read, expand and write a
     `mb_calib.json` filled with NANs.

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -4071,7 +4071,7 @@ class TestDynamicSpinup:
                    err_dmdtda_scaling_factor
 
         # test that error is raised if user provides flowlines but want to
-        # include inversion during dynamic mu calibration
+        # include inversion during dynamic melt_f calibration
         if do_inversion:
             # artificial change of flowlines to force error
             fls[0].thick = np.zeros(fls[0].nx)


### PR DESCRIPTION
Some small renamings of mu to melt_f.

And some general remarks:
- In `run_random_climate` the kwarg `mb_model` was deleted, but not in `run_constant_climate` and `run_from_climate_data`. Maybe we could make something like a `run_with_user_provided_mb_model`, where the user can/must provide a mb_model
- most of the test coverage is lost because of `@pytest.mark.skip` before `test_merged_simulation`
- `decide_winter_precip_factor` has no tests
- There are still some mu_star or t_star in the code:
  - flowline.py L3039
  - test_workflow.py L161, L173-L175
