### PR TITLE
added lock in monthly_process_isimip_data, removed t*,PastMassBalance

### DIFF
--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -3254,9 +3254,8 @@ def run_random_climate(gdir, nyears=1000, y0=None, halfsize=15,
         the glacier directory to process
     nyears : int
         length of the simulation
-    y0 : int, optional
-        central year of the random climate period. The default is to be
-        centred on t*.
+    y0 : int
+        central year of the random climate period. Has to be set!
     halfsize : int, optional
         the half-size of the time window (window size = 2 * halfsize + 1)
     bias : float
@@ -3370,8 +3369,7 @@ def run_constant_climate(gdir, nyears=1000, y0=None, halfsize=15,
         length of the simulation (default: as long as needed for reaching
         equilibrium)
     y0 : int
-        central year of the requested climate period. The default is to be
-        centred on t*.
+        central year of the random climate period. Has to be set!
     halfsize : int, optional
         the half-size of the time window (window size = 2 * halfsize + 1)
     bias : float

--- a/oggm/sandbox/edu.py
+++ b/oggm/sandbox/edu.py
@@ -44,9 +44,8 @@ class BiasedConstantMassBalance(MassBalanceModel):
         bias : float, optional
             set to the alternative value of the annual bias [mm we yr-1]
             you want to use (the default is to use the calibrated value)
-        y0 : int, optional, default: tstar
-            the year at the center of the period of interest. The default
-            is to use tstar as center.
+        y0 : int
+            the year at the center of the period of interest. Has to be set!
         halfsize : int, optional
             the half-size of the time window (window size = 2 * halfsize + 1)
         filename : str, optional
@@ -176,8 +175,7 @@ def run_constant_climate_with_bias(
         is to take the last year available
     bias : float
         bias of the mb model. Default is to use the calibrated one, which
-        is often a better idea. For t* experiments it can be useful to set it
-        to zero
+        is zero usually anyways.
     kwargs : dict
         kwargs to pass to the FluxBasedModel instance
     """

--- a/oggm/shop/gcm_climate.py
+++ b/oggm/shop/gcm_climate.py
@@ -196,7 +196,7 @@ def process_monthly_isimip_data(gdir, output_filesuffix='',
     member : str
         ensemble member gcm that you want to process
     ssp : str
-        ssp scenario to process (only 'ssp126' or 'ssp585' are available)
+        ssp scenario to process (only 'ssp126', 'ssp370' or 'ssp585' are available)
     year_range : tuple of str
         the year range for which the anomalies are computed
         (passed to process_gcm_gdata). Default for ISIMIP3b `('1979', '2014')
@@ -218,6 +218,7 @@ def process_monthly_isimip_data(gdir, output_filesuffix='',
     # Glacier location
     glon = gdir.cenlon
     glat = gdir.cenlat
+
     if testing:
         gcm_server = 'https://cluster.klima.uni-bremen.de/~oggm/test_climate/'
     else:
@@ -229,14 +230,13 @@ def process_monthly_isimip_data(gdir, output_filesuffix='',
     fpath_spec = path + '{}_w5e5_'.format(member) + '{ssp}_{var}' + add
     fpath_temp = fpath_spec.format(var='tasAdjust', ssp=ssp)
     fpath_temp_h = fpath_spec.format(var='tasAdjust', ssp='historical')
-
     fpath_precip = fpath_spec.format(var='prAdjust', ssp=ssp)
     fpath_precip_h = fpath_spec.format(var='prAdjust', ssp='historical')
-    fpath_temp = utils.file_downloader(fpath_temp)
-    fpath_temp_h = utils.file_downloader(fpath_temp_h)
-
-    fpath_precip = utils.file_downloader(fpath_precip)
-    fpath_precip_h = utils.file_downloader(fpath_precip_h)
+    with utils.get_lock():
+        fpath_temp = utils.file_downloader(fpath_temp)
+        fpath_temp_h = utils.file_downloader(fpath_temp_h)
+        fpath_precip = utils.file_downloader(fpath_precip)
+        fpath_precip_h = utils.file_downloader(fpath_precip_h)
 
     # Read the GCM files
     with xr.open_dataset(fpath_temp_h, use_cftime=True) as tempds_hist, \

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1793,9 +1793,10 @@ def compile_fixed_geometry_mass_balance(gdirs, filesuffix='',
 @global_task(log)
 def compile_ela(gdirs, filesuffix='', path=True, csv=False, ys=None, ye=None, years=None,
                 climate_filename='climate_historical', temperature_bias=None,
-                precipitation_factor=None, climate_input_filesuffix=''):
+                precipitation_factor=None, climate_input_filesuffix='',
+                mb_model_class='MonthlyTIModel'):
     """Compiles a table of ELA timeseries for all glaciers for a given years,
-    using the PastMassBalance model.
+    using the mb_model_class (default MonthlyTIModel).
 
     The file is stored in a hdf file (not csv) per default. Use pd.read_hdf
     to open it.
@@ -1829,6 +1830,8 @@ def compile_ela(gdirs, filesuffix='', path=True, csv=False, ys=None, ye=None, ye
         multiply a factor to the precipitation time series
         default is None and means that the precipitation factor from the
         calibration is applied which is cfg.PARAMS['prcp_fac']
+    mb_model_class : MassBalanceModel class
+        the MassBalanceModel class to use, default is MonthlyTIModel
     """
     from oggm.workflow import execute_entity_task
     from oggm.core.massbalance import compute_ela
@@ -1837,7 +1840,8 @@ def compile_ela(gdirs, filesuffix='', path=True, csv=False, ys=None, ye=None, ye
                                  climate_filename=climate_filename,
                                  climate_input_filesuffix=climate_input_filesuffix,
                                  temperature_bias=temperature_bias,
-                                 precipitation_factor=precipitation_factor)
+                                 precipitation_factor=precipitation_factor,
+                                 mb_model_class=mb_model_class)
 
     for idx, s in enumerate(out_df):
         if s is None:


### PR DESCRIPTION
- added `utils.get_lock()` for `utils.file_downloader`  of `monthly_process_isimip_data`. Otherwise, errors occur if the data is not yet downloaded and multiprocessing is applied
- also removed some more PastMassBalance and t* namings in the docstrings and made clear that `y0` has to be set in `run_random_climate` and `run_constant_climate`  (before tstar was the default)
 - and made `compile_ela` compatible to other future `mb_model_class`(es) 
